### PR TITLE
Clarify what this response is about.

### DIFF
--- a/cmd/epithet-oidc-plugin/response_template.go
+++ b/cmd/epithet-oidc-plugin/response_template.go
@@ -1,9 +1,9 @@
 package main
 
 const responseTpl = `
-{{ $title := "Authentication Succeeded" }}
+{{ $title := "SSH Authentication Succeeded" }}
 {{ if .Error }}
-	{{ $title = "Authentication Failed" }}
+	{{ $title = "SSH Authentication Failed" }}
 {{ end }}
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
The template used here is very generic and looks exactly like the response we get when using Okta as our k8s authentication provider. This may be confusing down the line for support, clarify it a little by showing it's the SSH Auth that's failing.