### PR TITLE
Build with go 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
     - name: Check out code
       uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.15.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1


### PR DESCRIPTION
The OIDC plugin should not make internal API calls like the epithet-agent https://github.com/epithet-ssh/epithet/pull/6
But it's a good idea to upgrade anyway.